### PR TITLE
Update genie path on travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7" COMPILER="clang" GMAKE_FOLDER="gmake-linux-clang"; fi
 
 script:
-  - mud/bin/genie --gcc=linux-$CC gmake
+  - mud/bin/linux/genie --gcc=linux-$CC gmake
   - cd build/projects/$GMAKE_FOLDER
   - make config=debug64
 


### PR DESCRIPTION
Hello! I was trying to get mud working on my machine, and saw that the travis buildings failed due the wrong path of `genie`. I updated it, tested on travis, and it's passing again.